### PR TITLE
Stop the service on Access Denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,7 @@
 1.4.1
 =====
 * Fix MockSQSClient to read config properly (as regular config does)
+
+1.7.0
+====
+* Make an access denied error stop the consumer, because it is fatal.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A configuration driven SQS client",
   "main": "build/index.js",
   "scripts": {

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -17,6 +17,9 @@ async function createConsumer(queueClient, context, handleMessage, options) {
   consumer.on('error', async (error) => {
     if (error.code === 'ExpiredToken') {
       consumer.sqs = await queueClient.reconnect(context, this.sqs);
+    } else if (error.code === 'AccessDenied') {
+      context.logger.error('Missing permission', context.service.wrapError(error, errorArgs));
+      consumer.stop();
     } else if (error.code === 'AWS.SimpleQueueService.NonExistentQueue') {
       context.logger.error('Misconfigured queue', context.service.wrapError(error, errorArgs));
       consumer.stop();


### PR DESCRIPTION
Usually access denied errors should be fatal to the service.   When this error is detected we send a stop message to the pod.