### PR TITLE
Add assumed role check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,7 @@
 1.7.0
 ====
 * Make an access denied error stop the consumer, because it is fatal.
+
+1.8.0
+====
+* Add assumed role check in the config.  If you add an assumedRole, on start we will check to see if the caller's identity Arn contains the assumedRole.  If not throw an error on start, to fail on startup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "A configuration driven SQS client",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A configuration driven SQS client",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { EventEmitter } from 'events';
-import { SQS } from 'aws-sdk';
+import { SQS, STS } from 'aws-sdk';
 import SqsQueue from './Queue';
 import { normalizeQueueConfig } from './util';
 
@@ -32,7 +32,7 @@ export default class ConfiguredSQSClient extends EventEmitter {
 
     this.config = config;
     this.logger = context.logger;
-    const { queues, endpoint, endpoints, accountId, region, subscriptions } = config;
+    const { queues, endpoint, endpoints, accountId, region, subscriptions, assumedRole } = config;
 
     this.defaultSubscriptionOptions = {
       waitTimeSeconds: 5,
@@ -75,6 +75,10 @@ export default class ConfiguredSQSClient extends EventEmitter {
       });
     }
 
+    if (assumedRole) {
+      this.assumedRole = assumedRole;
+    }
+
     normalizeQueueConfig(queues).forEach((queueConfig) => {
       const { logicalName, name } = queueConfig;
       const localName = logicalName || name;
@@ -87,6 +91,13 @@ export default class ConfiguredSQSClient extends EventEmitter {
   }
 
   async start(context) {
+    if (this.assumedRole){
+     const sts = new STS({apiVersion: '2011-06-15'});
+     const { Arn: actualRoleArn } = await sts.getCallerIdentity({}).promise();
+     if (!(actualRoleArn.includes(this.assumedRole))) {
+       throw new Error(`Role is ${actualRoleArn} expecting to contain ${this.assumedRole}`);
+     }
+    }
     await Promise.all(Object.entries(this.queues).map(([, q]) => q.start(context)));
     return this;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -91,12 +91,12 @@ export default class ConfiguredSQSClient extends EventEmitter {
   }
 
   async start(context) {
-    if (this.assumedRole){
-     const sts = new STS({apiVersion: '2011-06-15'});
-     const { Arn: actualRoleArn } = await sts.getCallerIdentity({}).promise();
-     if (!(actualRoleArn.includes(this.assumedRole))) {
-       throw new Error(`Role is ${actualRoleArn} expecting to contain ${this.assumedRole}`);
-     }
+    if (this.assumedRole) {
+      const sts = new STS({ apiVersion: '2011-06-15' });
+      const { Arn: actualRoleArn } = await sts.getCallerIdentity({}).promise();
+      if (!(actualRoleArn.includes(this.assumedRole))) {
+        throw new Error(`Role is ${actualRoleArn} expecting to contain ${this.assumedRole}`);
+      }
     }
     await Promise.all(Object.entries(this.queues).map(([, q]) => q.start(context)));
     return this;

--- a/tests/test_config.js
+++ b/tests/test_config.js
@@ -25,6 +25,7 @@ const qConfig = {
   subscriptions: {
     waitTimeSeconds: 1,
   },
+  assumedRole: 'user',
   contextFunction(context, message) {
     return {
       ...context,

--- a/tests/test_config.js
+++ b/tests/test_config.js
@@ -25,7 +25,7 @@ const qConfig = {
   subscriptions: {
     waitTimeSeconds: 1,
   },
-  assumedRole: 'user',
+  // assumedRole: 'user',
   contextFunction(context, message) {
     return {
       ...context,


### PR DESCRIPTION
Add a check for the assumed role.  

The reason for this is because a specific role will have the correct permissions for the queues.  If the assumed role doesn't match then we can kill the service on start, instead of waiting for failure on the first poll.