### PR TITLE
Retain message attributes while publishing to configured deadLetter queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ If your handler throws an error, the redrive policy of the queue takes over. How
 marks that error with a property "deadLetter" that is either true or the name of another queue, the
 failed attempt will be published on the target queue (either the deadLetter property of the queue that
 was configured in your configured-sqs-client config, or the queue specified in the deadLetter error property).
+
+Testing this package
+=====
+```
+docker run -p 9324:9324 gasbuddy/sqs-mock:latest
+npm run test
+```

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@gasbuddy/configured-sqs-client",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A configuration driven SQS client",
   "main": "build/index.js",
   "scripts": {
-    "test": "tap --no-coverage --node-arg=-r --node-arg=@babel/register tests/*.js",
+    "test": "tap --timeout=30 --no-coverage --node-arg=-r --node-arg=@babel/register tests/*.js",
     "test-some": "tap --node-arg=-r --node-arg=@babel/register",
     "cover": "cross-env BABEL_ENV=test tap tests/test_*.js",
     "lint": "eslint .",

--- a/src/util.js
+++ b/src/util.js
@@ -63,18 +63,20 @@ export function messageHandlerFunc(context, sqsQueue, handler) {
             logicalName: sqsQueue.config.logicalName,
           }));
         } else {
+          const msgAttributes = {
+            ...rest.MessageAttributes,
+            ErrorDetail: {
+              DataType: 'String',
+              StringValue: error.message,
+            },
+          };
           try {
             await sqsQueue.queueClient.publish(
               context,
               error.deadLetter === true ? sqsQueue.config.deadLetter : error.deadLetter,
               parsedMessage,
               {
-                MessageAttributes: {
-                  ErrorDetail: {
-                    DataType: 'String',
-                    StringValue: error.message,
-                  },
-                },
+                MessageAttributes: msgAttributes,
               },
             );
           } catch (sqsError) {


### PR DESCRIPTION
This change will also maintain the origin CorrelationId